### PR TITLE
Исправление утечек памяти

### DIFF
--- a/src/main/core/EventHandling/EventHandler.java
+++ b/src/main/core/EventHandling/EventHandler.java
@@ -33,21 +33,21 @@ public class EventHandler {
     private static void initCallbacks() {
         log("Thread: Event handling started");
 
-        glfwSetWindowSizeCallback(glfwWindow, new GLFWWindowSizeCallback() {
+        glfwSetWindowSizeCallback(glfwWindow, addResource(new GLFWWindowSizeCallback() {
             @Override
             public void invoke(long window, int width, int height) {
                 EventHandler.width = width;
                 EventHandler.height = height;
             }
-        });
-        glfwSetKeyCallback(glfwWindow, new GLFWKeyCallback() {
+        }));
+        glfwSetKeyCallback(glfwWindow, addResource(new GLFWKeyCallback() {
             @Override
             public void invoke(long window, int key, int scancode, int action, int mods) {
                 if (key == GLFW.GLFW_KEY_F4 && mods == GLFW.GLFW_MOD_ALT) {
                     Logger.logExit(1863);
                 }
             }
-        });
+        }));
     }
 
     public static void startKeyLogging() {

--- a/src/main/core/EventHandling/Logging/Logger.java
+++ b/src/main/core/EventHandling/Logging/Logger.java
@@ -10,6 +10,7 @@ import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Random;
 import static core.EventHandling.Logging.Config.getFromConfig;
 import static core.Window.*;
@@ -155,7 +156,11 @@ public class Logger extends PrintStream {
     private static StringBuilder getStartMessage() {
         StringBuilder message = new StringBuilder();
 
-        message.append(!System.getProperty("os.name").toLowerCase().contains("windows 10") ? "Warning: " + System.getProperty("os.name") + " not supported!\n" : "");
+        String os = System.getProperty("os.name");
+        String identifier = os.toLowerCase(Locale.ROOT);
+        if (!identifier.contains("windows 10") && !identifier.contains("linux")) {
+            message.append("Warning: ").append(os).append(" not supported!\n");
+        }
         message.append("\nGLFW version: ").append(glfwGetVersionString());
         message.append("\nGame version: " + Window.version);
         message.append("\nStart time: ").append(LocalDateTime.now());

--- a/src/main/core/InputHandler.java
+++ b/src/main/core/InputHandler.java
@@ -9,12 +9,13 @@ import org.lwjgl.glfw.GLFWMouseButtonCallback;
 import java.awt.*;
 import java.util.Arrays;
 
+import static core.Window.addResource;
 import static core.Window.glfwWindow;
 import static org.lwjgl.glfw.GLFW.*;
 
 public class InputHandler {
     static final int PRESSED_ARRAY_SIZE = 349;
-    static final int CLICKED_ARRAY_SIZE = 5; // взял с потолка
+    static final int CLICKED_ARRAY_SIZE = 8; // GLFW_MOUSE_BUTTON_1 ~ GLFW_MOUSE_BUTTON_8
 
     private final long[] pressed, clicked;
     private final long[] justPressed, justClicked;
@@ -31,7 +32,7 @@ public class InputHandler {
     }
 
     public void init() {
-        glfwSetCursorPosCallback(glfwWindow, new GLFWCursorPosCallback() {
+        glfwSetCursorPosCallback(glfwWindow, addResource(new GLFWCursorPosCallback() {
             @Override
             public void invoke(long window, double xpos, double ypos) {
                 double mouseX = xpos * MouseCalibration.xMultiplier;
@@ -41,8 +42,8 @@ public class InputHandler {
                 lastMouseMoveTimestamp = System.currentTimeMillis();
                 mousePos.setLocation(mouseX, invertedY);
             }
-        });
-        glfwSetKeyCallback(glfwWindow, new GLFWKeyCallback() {
+        }));
+        glfwSetKeyCallback(glfwWindow, addResource(new GLFWKeyCallback() {
             @Override
             public void invoke(long window, int key, int scancode, int action, int mods) {
                 switch (action) {
@@ -56,8 +57,8 @@ public class InputHandler {
                     }
                 }
             }
-        });
-        glfwSetMouseButtonCallback(glfwWindow, new GLFWMouseButtonCallback() {
+        }));
+        glfwSetMouseButtonCallback(glfwWindow, addResource(new GLFWMouseButtonCallback() {
             @Override
             public void invoke(long window, int button, int action, int mods) {
                 switch (action) {
@@ -71,7 +72,7 @@ public class InputHandler {
                     }
                 }
             }
-        });
+        }));
     }
 
     public void update() {


### PR DESCRIPTION
В соответствии с примерами от glfw, стоит применять `glfwTerminate()` при закрытии окна. Но не стоит забывать и про lwjgl, который генерирует специальные нативные структуры для реализации вызова колбеков из нативного кода. Собственно здесь я добавил удаление выделенных структур при закрытии окна, но это не затрагивает случаи, когда приложение закрывается другим способом (например крашнулось) и по очень простой причине - нужно доработать обработку исключений (из любых мест).  Также сделал создание окна под wayland (для других WM автоопределение не должно сбоить)